### PR TITLE
Fixed issue with render array titles.

### DIFF
--- a/html_title.module
+++ b/html_title.module
@@ -32,6 +32,9 @@ function html_title_preprocess_page_title(&$variables) {
 function html_title_preprocess_breadcrumb(&$vars) {
   $last = &$vars['breadcrumb'][count($vars['breadcrumb']) - 1];
   if (!isset($last['url'])) {
+    if (!is_string($last['text'])) {
+      $last['text'] = \Drupal::service('renderer')->renderPlain($last['text']);
+    }
     $last['text'] = \Drupal::service('html_title.filter')->decodeToMarkup($last['text']);
   }
 }


### PR DESCRIPTION
* Sometimes titles is presented as render array. Thus the breadcrumb generated is shown as "Array" This needed to be converted to plain text. 

Kindly let me know if something is missing. 
Thanks!